### PR TITLE
Make example submit form, not click button

### DIFF
--- a/fullstack/browser/app.js
+++ b/fullstack/browser/app.js
@@ -31,7 +31,9 @@ module.exports = class App {
       }</ul>
       <div class="new-task">
         <input name="name" binding=${[model, 'name']} />
-        <button onclick=${() => this.addTask()}>Add task</button>
+        <form onsubmit=${() => this.addTask()}>
+          <input type="submit" value="Add task" />
+        </form>
       </div>
     </div>`
   }

--- a/fullstack/test/tasksSpec.js
+++ b/fullstack/test/tasksSpec.js
@@ -49,7 +49,7 @@ describe('tasks', () => {
 
     const newTask = monkey.find('.new-task')
     await newTask.find('[name=name]').typeIn('Task 1')
-    await newTask.find('button').click()
+    await newTask.click('Add task')
 
     await monkey.find('.task').shouldHave({text: [
       'Task 1'
@@ -59,4 +59,3 @@ describe('tasks', () => {
     expect(results).to.eql([{name: 'Task 1'}])
   })
 })
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CLI to create a new project with the Featurist stack",
   "bin": "./bin/featurist",
   "scripts": {
-    "test": "mocha test && (cd fullstack && npm test)"
+    "test": "mocha --harmony test && (cd fullstack && npm test)"
   },
   "keywords": [
     "featurist",


### PR DESCRIPTION
A good example of how semantic finders are resilient to markup changes :)